### PR TITLE
Ignore case when looking for SWMM Input cards

### DIFF
--- a/hymo/swmminp.py
+++ b/hymo/swmminp.py
@@ -110,6 +110,26 @@ class SWMMInpFile(BaseReader):
 
         self._check_headers()
 
+    def find_line_num(self, line, lookup=None):
+        """
+        Given a text string returns the line number that the string
+        appears in.
+
+        Requires:
+        - line: str, text to look up.
+
+        Returns:
+        - n: int, the line number where line exists.
+        """
+        if lookup is None:
+            currentfile = self.orig_file.copy()
+        else:
+            currentfile = lookup.copy()
+        for n, l in enumerate(currentfile):
+            if l.lower().find(line.lower()) > -1:
+                break
+        return n
+    
     def BlockDoesNotExistWarning(self):
         raise(NotImplementedError)
         # TODO


### PR DESCRIPTION
This PR allows SWMM model cards to be created ignoring case. This was done specifically to address the fact that SWMM5.1.12 creates the card [Polygons] and PCSWMM creates the card [POLYGONS].

Sensible people can see that clearly PCSWMM is right since all other cards in the input file are [ALL_CAPS], but here we are.