### PR TITLE
fixes #26 and #27

### DIFF
--- a/hymo/swmminp.py
+++ b/hymo/swmminp.py
@@ -373,7 +373,7 @@ class SWMMInpFile(BaseReader):
 
             self._outfalls = (
                 self._make_df('outfalls', comment=';', sep='\s+', header=None,
-                              names=names, index_col=[0], skiprows=1, dtype=dtype))
+                              names=names, index_col=[0], dtype=dtype))
 
         return self._outfalls
 

--- a/hymo/swmminp.py
+++ b/hymo/swmminp.py
@@ -213,9 +213,13 @@ class SWMMInpFile(BaseReader):
                 'Source', 'Path'
             ]
 
+            dtype = {
+                'Name': str,
+            }
+
             self._raingages = (
                 self._make_df('raingages', comment=';', sep='\s+', header=None,
-                              names=names, index_col=[0]))
+                              names=names, index_col=[0], dtype=dtype))
 
         return self._raingages
 
@@ -231,9 +235,14 @@ class SWMMInpFile(BaseReader):
                 'SnowPack'
             ]
 
+            dtype = {
+                'Name': str,
+                'Rain_Gage': str,
+            }
+
             self._subcatchments = (
                 self._make_df('subcatchments', comment=';', sep='\s+', header=None,
-                              names=names, index_col=[0]))
+                              names=names, index_col=[0], dtype=dtype))
 
         return self._subcatchments
 
@@ -247,9 +256,14 @@ class SWMMInpFile(BaseReader):
                 'RouteTo', 'PctRouted'
             ]
 
+            dtype = {
+                'Subcatchment': str,
+                'RouteTo': str,
+            }
+
             self._subareas = (
                 self._make_df('subareas', comment=';', sep='\s+', header=None,
-                              names=names, index_col=[0]))
+                              names=names, index_col=[0], dtype=dtype))
 
         return self._subareas
 
@@ -258,9 +272,13 @@ class SWMMInpFile(BaseReader):
         if self._infiltration is None:
             names = ['Subcatchment', 'Suction', 'HydCon', 'IMDmax']
 
+            dtype = {
+                'Subcatchment': str,
+            }
+
             self._infiltration = (
                 self._make_df('infiltration', comment=';', sep='\s+', header=None,
-                              names=names, index_col=[0]))
+                              names=names, index_col=[0], dtype=dtype))
 
         return self._infiltration
 
@@ -325,9 +343,14 @@ class SWMMInpFile(BaseReader):
                 'Max_Depth', 'Init_Depth',
                 'Surcharge_Depth', 'Ponded_Area'
                 ]
+
+            dtype = {
+                'Name': str,
+            }
+
             self._junctions = (
                 self._make_df('junctions', comment=';', sep='\s+', header=None,
-                              names=names, index_col=[0]))
+                              names=names, index_col=[0], dtype=dtype))
 
         return self._junctions
 
@@ -340,9 +363,15 @@ class SWMMInpFile(BaseReader):
                 'Outfall_Type', 'Stage_Table_Time_Series',
                 'Tide_Gate', 'Route_To'
             ]
+
+            dtype = {
+                'Name': str,
+                'Outfall_Type': str, 
+            }
+
             self._outfalls = (
                 self._make_df('outfalls', comment=';', sep='\s+', header=None,
-                              names=names, index_col=[0], skiprows=1))
+                              names=names, index_col=[0], skiprows=1, dtype=dtype))
 
         return self._outfalls
 
@@ -370,8 +399,16 @@ class SWMMInpFile(BaseReader):
                 'Outlet_Offset', 'Init_Flow',
                 'Max_Flow',
             ]
-            self._conduits = self._make_df('conduits',
-                comment=';', sep='\s+', header=None, names=names, index_col=[0])
+
+            dtype = {
+                'Name': str,
+                'Inlet_Node': str, 
+                'Outlet_Node': str
+            }
+
+            self._conduits = (
+                self._make_df('conduits', comment=';', sep='\s+', header=None, 
+                              names=names, index_col=[0], dtype=dtype))
 
         return self._conduits
 
@@ -384,9 +421,17 @@ class SWMMInpFile(BaseReader):
             names = [
                 'Name', 'From_Node', 'To_Node', 'Type', 'Offset', 
                 'Qcoeff', 'Gated', 'CloseTime' ]
+
+            dtype = {
+                'Name': str,
+                'From_Node': str, 
+                'To_Node': str,
+                'Type': str
+            }
+
             self._orifices = (
                 self._make_df('orifices', comment=';', sep='\s+', header=None,
-                              names=names, index_col=[0]))
+                              names=names, index_col=[0], dtype=dtype))
 
         return self._orifices
 
@@ -400,9 +445,16 @@ class SWMMInpFile(BaseReader):
                 'Outlet_Type', 'Qcoeff_QTable',
                 'Qexpon', 'Flap_Gate',
             ]
+
+            dtype = {
+                'Name': str,
+                'Inlet_Node': str, 
+                'Outlet_Node': str
+            }
+
             self._outlets = (
                 self._make_df('outlets', comment=';', sep='\s+', header=None,
-                              names=names, index_col=[0]))
+                              names=names, index_col=[0], dtype=dtype))
 
         return self._outlets
 
@@ -415,9 +467,17 @@ class SWMMInpFile(BaseReader):
                 'CrestHt', 'Qcoeff', 'Gated', 'EndCon',
                 'EndCoeff', 'Surcharge', 'RoadWidth', 'RoadSurf'
             ]
+
+            dtype = {
+                'Name': str,
+                'From_Node': str, 
+                'To_Node': str,
+                'Type': str
+            }
+
             self._weirs = (
                 self._make_df('weirs', comment=';', sep='\s+', header=None,
-                              names=names, index_col=[0]))
+                              names=names, index_col=[0], dtype=dtype))
 
         return self._weirs
 
@@ -430,9 +490,14 @@ class SWMMInpFile(BaseReader):
                 'Geom2', 'Geom3', 'Geom4',
                 'Barrels'
             ]
+
+            dtype = {
+                'Link': str,
+            }
+
             self._xsections = (
                 self._make_df('xsections', comment=';', sep='\s+', header=None,
-                              names=names, index_col=[0]))
+                              names=names, index_col=[0], dtype=dtype))
 
         return self._xsections
 
@@ -455,9 +520,15 @@ class SWMMInpFile(BaseReader):
                 'Link', 'Inlet', 'Outlet',
                 'Average', 'Flap_Gate', 'SeepageRate'
             ]
+
+            dtype = {
+                'Link': str,
+                'Inlet': str,
+                'Outlet': str,
+            }
             self._losses = (
                 self._make_df('losses', comment=';', sep='\s+', header=None,
-                              names=names, index_col=[0]))
+                              names=names, index_col=[0], dtype=dtype))
 
         return self._losses
 
@@ -465,9 +536,10 @@ class SWMMInpFile(BaseReader):
     def curves(self):
         if self._curves is None:
             names = ['Name', 'Type', 'X_Value', 'Y_Value']
+            dtype = {'Name': str}
             self._curves = (
                 self._make_df('curves', comment=';', sep='\s+', header=None,
-                              names=names, index_col=[0]))
+                              names=names, index_col=[0], dtype=dtype))
 
         return self._curves
 
@@ -476,9 +548,10 @@ class SWMMInpFile(BaseReader):
     def timeseries(self):
         if self._timeseries is None:
             names = ['Name', 'Date', 'Time', 'Value']
+            dtype = {'Name': str}
             self._timeseries = (
                 self._make_df('timeseries', comment=';', sep='\s+', header=None,
-                              names=names, index_col=[0]))
+                              names=names, index_col=[0], dtype=dtype))
 
         return self._timeseries
 
@@ -499,9 +572,10 @@ class SWMMInpFile(BaseReader):
 
         if self._tags is None:
             names = ['Object', 'Name', 'Type']
+            dtype = {'Name': str}
             self._tags = (
                 self._make_df('tags', comment=';', sep='\s+', header=None,
-                              names=names, index_col=[0]))
+                              names=names, index_col=[0], dtype=dtype))
 
         return self._tags
 
@@ -523,9 +597,10 @@ class SWMMInpFile(BaseReader):
     def coordinates(self):
         if self._coordinates is None:
             names = ['Node', 'X_Coord', 'Y_Coord']
+            dtype = {'Node': str}
             self._coordinates = (
                 self._make_df('coordinates', comment=';', sep='\s+', header=None,
-                              names=names, index_col=[0]))
+                              names=names, index_col=[0], dtype=dtype))
 
         return self._coordinates
 
@@ -534,9 +609,10 @@ class SWMMInpFile(BaseReader):
     def vertices(self):
         if self._vertices is None:
             names = ['Link', 'X_Coord', 'Y_Coord']
+            dtype = {'Link': str}
             self._vertices = (
                 self._make_df('vertices', comment=';', sep='\s+', header=None,
-                              names=names, index_col=[0]))
+                              names=names, index_col=[0], dtype=dtype))
 
         return self._vertices
 
@@ -545,9 +621,10 @@ class SWMMInpFile(BaseReader):
     def polygons(self):
         if self._polygons is None:
             names = ['Subcatchment', 'X_Coord', 'Y_Coord']
+            dtype = {'Subcatchment': str}
             self._polygons = (
                 self._make_df('polygons', comment=';', sep='\s+', header=None,
-                              names=names, index_col=[0]))
+                              names=names, index_col=[0], dtype=dtype))
 
         return self._polygons
 
@@ -556,9 +633,10 @@ class SWMMInpFile(BaseReader):
     def symbols(self):
         if self._symbols is None:
             names = ['Gage', 'X_Coord', 'Y_Coord']
+            dtype = {'Gage': str}
             self._symbols = (
                 self._make_df('symbols', comment=';', sep='\s+', header=None,
-                              names=names, index_col=[0]))
+                              names=names, index_col=[0], dtype=dtype))
 
         return self._symbols
 
@@ -568,8 +646,9 @@ class SWMMInpFile(BaseReader):
             names = ['Name', 'Units', 'Crain', 'Cgw',
                         'Crdii', 'Kdecay', 'SnowOnly',
                         'Co_Pollutant', 'Co_Frac', 'Cdwf', 'Cinit']
+            dtype = {'Name': str}
             self._pollutants = (
                 self._make_df('pollutants', comment=';', sep='\s+', header=None,
-                              names=names, index_col=[0]))
+                              names=names, index_col=[0], dtype=dtype))
 
         return self._pollutants

--- a/hymo/swmminp.py
+++ b/hymo/swmminp.py
@@ -1,5 +1,6 @@
 import warnings
 import pandas as pd
+import numpy as np
 
 from .base_reader import BaseReader
 
@@ -238,6 +239,7 @@ class SWMMInpFile(BaseReader):
             dtype = {
                 'Name': str,
                 'Rain_Gage': str,
+                'Outlet': str,
             }
 
             self._subcatchments = (
@@ -597,7 +599,11 @@ class SWMMInpFile(BaseReader):
     def coordinates(self):
         if self._coordinates is None:
             names = ['Node', 'X_Coord', 'Y_Coord']
-            dtype = {'Node': str}
+            dtype = {
+                'Node': str,
+                'X_Coord': np.float64, 
+                'Y_Coord': np.float64,
+            }
             self._coordinates = (
                 self._make_df('coordinates', comment=';', sep='\s+', header=None,
                               names=names, index_col=[0], dtype=dtype))
@@ -609,7 +615,11 @@ class SWMMInpFile(BaseReader):
     def vertices(self):
         if self._vertices is None:
             names = ['Link', 'X_Coord', 'Y_Coord']
-            dtype = {'Link': str}
+            dtype = {
+                'Link': str,
+                'X_Coord': np.float64, 
+                'Y_Coord': np.float64,
+            }
             self._vertices = (
                 self._make_df('vertices', comment=';', sep='\s+', header=None,
                               names=names, index_col=[0], dtype=dtype))
@@ -621,7 +631,13 @@ class SWMMInpFile(BaseReader):
     def polygons(self):
         if self._polygons is None:
             names = ['Subcatchment', 'X_Coord', 'Y_Coord']
-            dtype = {'Subcatchment': str}
+            
+            dtype = {
+                'Subcatchment': str,
+                'X_Coord': np.float64, 
+                'Y_Coord': np.float64,
+            }
+
             self._polygons = (
                 self._make_df('polygons', comment=';', sep='\s+', header=None,
                               names=names, index_col=[0], dtype=dtype))

--- a/hymo/swmmreport.py
+++ b/hymo/swmmreport.py
@@ -51,10 +51,11 @@ class SWMMReportFile(BaseReader):
         The parsed node depth results as a pandas DataFrame
         """
         if self._subcatchment_runoff_results is None:
-            names = self._headers.subcatchment_runoff_results
+            names, dtype = self._headers.subcatchment_runoff_results
 
             self._subcatchment_runoff_results = self._make_df(
-                'subcatchment_runoff', sep='\s+', header=None, names=names, index_col=[0])
+                'subcatchment_runoff', sep='\s+', header=None, names=names, 
+                index_col=[0], dtype=dtype)
 
         return self._subcatchment_runoff_results
 
@@ -65,10 +66,11 @@ class SWMMReportFile(BaseReader):
         """
         if self._node_depth_results is None:
             #TODO check names and make consistent with new properties
-            names = self._headers.node_depth_results
+            names, dtype = self._headers.node_depth_results
 
             self._node_depth_results = self._make_df(
-                'node_depth', sep='\s+', header=None, names=names, index_col=[0])
+                'node_depth', sep='\s+', header=None, names=names, 
+                index_col=[0], dtype=dtype)
 
         return self._node_depth_results
 
@@ -78,10 +80,11 @@ class SWMMReportFile(BaseReader):
         The parsed node inflow results as a pandas DataFrame
         """
         if self._node_inflow_results is None:
-            names = self._headers.node_inflow_results
+            names, dtype = self._headers.node_inflow_results
 
             self._node_inflow_results = self._make_df(
-                'node_inflow', sep='\s+', header=None, names=names, index_col=[0])
+                'node_inflow', sep='\s+', header=None, names=names, 
+                index_col=[0], dtype=dtype)
 
         return self._node_inflow_results
 
@@ -92,30 +95,33 @@ class SWMMReportFile(BaseReader):
         """
         if self._node_surcharge_results is None:
             #TODO check names and make consistent with new properties
-            names = self._headers.node_surcharge_results
+            names, dtype = self._headers.node_surcharge_results
 
             self._node_surcharge_results = self._make_df(
-                'node_surcharge', sep='\s+', header=None, names=names, index_col=[0])
+                'node_surcharge', sep='\s+', header=None, names=names, 
+                index_col=[0], dtype=dtype)
 
         return self._node_surcharge_results
 
     @property
     def node_flooding_results(self):
         if self._node_flooding_results is None:
-            names = self._headers.node_flooding_results
+            names, dtype = self._headers.node_flooding_results
 
             self._node_flooding_results = self._make_df(
-                'node_flooding', sep='\s+', header=None, names=names, index_col=[0])
+                'node_flooding', sep='\s+', header=None, names=names, 
+                index_col=[0], dtype=dtype)
 
         return self._node_flooding_results
 
     @property
     def storage_volume_results(self):
         if self._storage_volume_results is None:
-            names = self._headers.storage_volume_results
+            names, dtype = self._headers.storage_volume_results
 
             self._storage_volume_results = self._make_df(
-                'storage_volume', sep='\s+', header=None, names=names, index_col=[0])
+                'storage_volume', sep='\s+', header=None, names=names, 
+                index_col=[0], dtype=dtype)
 
         return self._storage_volume_results
 
@@ -135,9 +141,10 @@ class SWMMReportFile(BaseReader):
             n = '_'.join(names[:2])
             _ = names.pop(0)
             names[0] = n
+            dtype = {'Outfall_Node': str}
 
             df = self._make_df('outfall_loading', sep='\s+',
-                header=None, names=names, index_col=[0])
+                header=None, names=names, index_col=[0], dtype=dtype)
 
             # drop sep
             drop_from_index = [_ for _ in df.index if '-' in _]
@@ -150,20 +157,22 @@ class SWMMReportFile(BaseReader):
     @property
     def link_flow_results(self):
         if self._link_flow_results is None:
-            names = self._headers.link_flow_results
+            names, dtype = self._headers.link_flow_results
 
             self._link_flow_results = self._make_df(
-                'link_flow', sep='\s+', header=None, names=names, index_col=[0])
+                'link_flow', sep='\s+', header=None, names=names, 
+                index_col=[0], dtype=dtype)
 
         return self._link_flow_results
 
     @property
     def flow_classification_results(self):
         if self._flow_classification_results is None:
-            names = self._headers.flow_classification_results
+            names, dtype = self._headers.flow_classification_results
 
             self._flow_classification_results = self._make_df(
-                'flow_classification', sep='\s+', header=None, names=names, index_col=[0])
+                'flow_classification', sep='\s+', header=None, names=names, 
+                index_col=[0], dtype=dtype)
 
         return self._flow_classification_results
 
@@ -173,10 +182,11 @@ class SWMMReportFile(BaseReader):
             # There are some EOF lines that we need to exclude.
             # For now the _find_end function detects the end of
             # block because of the 2xSpace+return.
-            names = self._headers.conduit_surcharge_results
+            names, dtype = self._headers.conduit_surcharge_results
 
             self._conduit_surcharge_results = self._make_df(
-                'conduit_surcharge', sep='\s+', header=None, names=names, index_col=[0])
+                'conduit_surcharge', sep='\s+', header=None, names=names, 
+                index_col=[0], dtype=dtype)
 
         return self._conduit_surcharge_results
 
@@ -189,11 +199,13 @@ class SWMMReportFile(BaseReader):
             start_line_str = 'Link Pollutant Load Summary'
             blank_space = 3
             n_lines = 2
+            dtype = {'Link': str}
 
             names = self.infer_columns(start_line_str, blank_space, n_lines)
 
             self._link_pollutant_load_results = self._make_df(
-                'link_pollutant_load', sep='\s+', header=None, names=names, index_col=[0])
+                'link_pollutant_load', sep='\s+', header=None, names=names, 
+                index_col=[0], dtype=dtype)
 
         return self._link_pollutant_load_results
 
@@ -229,8 +241,8 @@ class _ReportHeaders(object):
                 'Total_Infil_mm', 'Total_Runoff_mm',
                 'Total_Runoff_mltr', 'Peak_Runoff_LPS',
                 'Runoff_Coeff']
-
-        return names
+        dtype = {'Subcatchment': str}
+        return names, dtype
 
     @property
     def node_depth_results(self):
@@ -248,8 +260,8 @@ class _ReportHeaders(object):
                 'Maximum_HGL_Meters', 'Time_of_Max_Occurrence_days',
                 'Time_of_Max_Occurrence_hours', 'Reported_Max_Depth_Meters'
             ]
-
-        return names
+        dtype = {'Node': str}
+        return names, dtype
 
     @property
     def node_inflow_results(self):
@@ -269,8 +281,8 @@ class _ReportHeaders(object):
                 'Lateral_Inflow_Volume_mltr', 'Total_Inflow_Volume_mltr',
                 'Flow_Balance_Error_Percent', 'flag'
             ]
-
-        return names
+        dtype = {'Node': str}
+        return names, dtype
 
     @property
     def node_surcharge_results(self):
@@ -287,7 +299,8 @@ class _ReportHeaders(object):
                 'Min_Depth_Below_Rim_Meters'
             ]
 
-        return names
+        dtype = {'Node': str}
+        return names, dtype
 
     @property
     def node_flooding_results(self):
@@ -306,7 +319,8 @@ class _ReportHeaders(object):
                 'Total_Flood_Volume_mltr', 'Maximum_Ponded_Depth_Meters'
             ]
 
-        return names
+        dtype = {'Node': str}
+        return names, dtype
 
     @property
     def storage_volume_results(self):
@@ -327,7 +341,8 @@ class _ReportHeaders(object):
                 'Time_of_Max_Occurrence_hours', 'Maximum_Outflow_LPS'
             ]
 
-        return names
+        dtype = {'Storage_Unit': str}
+        return names, dtype
 
 
     @property
@@ -347,7 +362,8 @@ class _ReportHeaders(object):
                 'Max_Full_Flow', 'Max_Full_Depth'
             ]
 
-        return names
+        dtype = {'Link': str}
+        return names, dtype
 
     @property
     def flow_classification_results(self):
@@ -360,7 +376,8 @@ class _ReportHeaders(object):
             'Fraction_of_Time_Inlet_Ctrl',
         ]
 
-        return names
+        dtype = {'Conduit': str}
+        return names, dtype
 
     @property
     def conduit_surcharge_results(self):
@@ -370,4 +387,5 @@ class _ReportHeaders(object):
             'Hours_Above_Full_Normal_Flow', 'Hours_Capacity_Limited',
         ]
 
-        return names
+        dtype = {'Conduit': str}
+        return names, dtype


### PR DESCRIPTION
* fix the skipline call that caused #26 to not read in first outlet device

* fix the dtypes in #27 so that user input stirngs (names, downstream nodes, etc) are forced to be names. Also added numeric types for super-long blocks like vertices and coordinates so that pandas can read them faster. Significant slowdowns can occur in files with >1M polygon vertices when dtype must be inferred.