### PR TITLE
added minimal support for flow-network related elements

### DIFF
--- a/hymo/tests/test_swmminp.py
+++ b/hymo/tests/test_swmminp.py
@@ -62,9 +62,8 @@ class base_SWMMInpFileMixin(object):
         assert hasattr(self.inp, 'outfalls')
         assert isinstance(self.inp.outfalls, pd.DataFrame)
 
-        with pytest.raises(NotImplementedError):
-            assert hasattr(self.inp, 'storage')
-            assert isinstance(self.inp.storage, pd.DataFrame)
+        assert hasattr(self.inp, 'storage')
+        assert isinstance(self.inp.storage, pd.DataFrame)
 
         assert hasattr(self.inp, 'conduits')
         assert isinstance(self.inp.conduits, pd.DataFrame)

--- a/hymo/tests/test_swmminp.py
+++ b/hymo/tests/test_swmminp.py
@@ -65,6 +65,9 @@ class base_SWMMInpFileMixin(object):
         assert hasattr(self.inp, 'storage')
         assert isinstance(self.inp.storage, pd.DataFrame)
 
+        assert hasattr(self.inp, 'dividers')
+        assert isinstance(self.inp.dividers, pd.DataFrame)
+
         assert hasattr(self.inp, 'conduits')
         assert isinstance(self.inp.conduits, pd.DataFrame)
 
@@ -73,6 +76,9 @@ class base_SWMMInpFileMixin(object):
 
         assert hasattr(self.inp, 'weirs')
         assert isinstance(self.inp.weirs, pd.DataFrame)
+
+        assert hasattr(self.inp, 'pumps')
+        assert isinstance(self.inp.pumps, pd.DataFrame)
 
         assert hasattr(self.inp, 'xsections')
         assert isinstance(self.inp.xsections, pd.DataFrame)


### PR DESCRIPTION
We need these elements for minimum network connective elements to be determined by the inp file alone. This is also important for determining the type/card for each network element from the inp file.

There is very little useful data in these cards, but this PR is just limiting the read_csv call to the first 3-5 columns of data so that we can get the minimal attributes necessary to build a flow network in memory.